### PR TITLE
Make WebGPU an option

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,10 @@ import { AudioManager } from "./components/AudioManager";
 import Transcript from "./components/Transcript";
 import { useTranscriber } from "./hooks/useTranscriber";
 
-// @ts-ignore
-const IS_WEBGPU_AVAILABLE = !!navigator.gpu;
-
 function App() {
     const transcriber = useTranscriber();
 
-    return IS_WEBGPU_AVAILABLE ? (
+    return (
         <div className='flex justify-center items-center min-h-screen'>
             <div className='container flex flex-col justify-center items-center'>
                 <h1 className='text-5xl font-extrabold tracking-tight text-slate-900 sm:text-7xl text-center'>
@@ -30,12 +27,6 @@ function App() {
                     🤗 Transformers.js
                 </a>
             </div>
-        </div>
-    ) : (
-        <div className='fixed w-screen h-screen bg-black z-10 bg-opacity-[92%] text-white text-2xl font-semibold flex justify-center items-center text-center'>
-            WebGPU is not supported
-            <br />
-            by this browser :&#40;
         </div>
     );
 }

--- a/src/components/AudioManager.tsx
+++ b/src/components/AudioManager.tsx
@@ -385,6 +385,10 @@ function SettingsModal(props: {
         size: value,
         id: `${key}${props.transcriber.multilingual || key.includes("/distil-") ? "" : ".en"}`,
     }));
+
+    // @ts-ignore
+    const IS_WEBGPU_AVAILABLE = !!navigator.gpu;
+
     return (
         <Modal
             show={props.show}
@@ -432,6 +436,7 @@ function SettingsModal(props: {
                                 id='gpu'
                                 type='checkbox'
                                 checked={props.transcriber.gpu}
+                                disabled={!IS_WEBGPU_AVAILABLE}
                                 onChange={(e) => {
                                     props.transcriber.setGPU(
                                         e.target.checked,
@@ -439,7 +444,7 @@ function SettingsModal(props: {
                                 }}
                             ></input>
                             <label htmlFor={"gpu"} className='ms-1'>
-                                GPU
+                                {IS_WEBGPU_AVAILABLE ? "GPU" : "GPU (unsupported browser)"}
                             </label>
                         </div>
                     </div>

--- a/src/components/AudioManager.tsx
+++ b/src/components/AudioManager.tsx
@@ -406,7 +406,7 @@ function SettingsModal(props: {
                             >{`${id} (${size}MB)`}</option>
                         ))}
                     </select>
-                    <div className='flex justify-end items-center mb-3 px-1'>
+                    <div className='flex justify-between items-center mb-3 px-1'>
                         <div className='flex'>
                             <input
                                 id='multilingual'
@@ -425,6 +425,21 @@ function SettingsModal(props: {
                             ></input>
                             <label htmlFor={"multilingual"} className='ms-1'>
                                 Multilingual
+                            </label>
+                        </div>
+                        <div className='flex'>
+                            <input
+                                id='gpu'
+                                type='checkbox'
+                                checked={props.transcriber.gpu}
+                                onChange={(e) => {
+                                    props.transcriber.setGPU(
+                                        e.target.checked,
+                                    );
+                                }}
+                            ></input>
+                            <label htmlFor={"gpu"} className='ms-1'>
+                                GPU
                             </label>
                         </div>
                     </div>

--- a/src/hooks/useTranscriber.ts
+++ b/src/hooks/useTranscriber.ts
@@ -37,6 +37,8 @@ export interface Transcriber {
     setModel: (model: string) => void;
     multilingual: boolean;
     setMultilingual: (model: boolean) => void;
+    gpu: boolean;
+    setGPU: (model: boolean) => void;
     subtask: string;
     setSubtask: (subtask: string) => void;
     language?: string;
@@ -112,6 +114,7 @@ export function useTranscriber(): Transcriber {
     const [multilingual, setMultilingual] = useState<boolean>(
         Constants.DEFAULT_MULTILINGUAL,
     );
+    const [gpu, setGPU] = useState<boolean>(Constants.DEFAULT_GPU);
     const [language, setLanguage] = useState<string>(
         Constants.DEFAULT_LANGUAGE,
     );
@@ -146,13 +149,14 @@ export function useTranscriber(): Transcriber {
                     audio,
                     model,
                     multilingual,
+                    gpu,
                     subtask: multilingual ? subtask : null,
                     language:
                         multilingual && language !== "auto" ? language : null,
                 });
             }
         },
-        [webWorker, model, multilingual, subtask, language],
+        [webWorker, model, multilingual, gpu, subtask, language],
     );
 
     const transcriber = useMemo(() => {
@@ -167,6 +171,8 @@ export function useTranscriber(): Transcriber {
             setModel,
             multilingual,
             setMultilingual,
+            gpu,
+            setGPU,
             subtask,
             setSubtask,
             language,

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -33,4 +33,5 @@ export default {
     DEFAULT_LANGUAGE: "english",
     DEFAULT_QUANTIZED: isMobileOrTablet,
     DEFAULT_MULTILINGUAL: true,
+    DEFAULT_GPU: false,
 };

--- a/src/worker.js
+++ b/src/worker.js
@@ -23,7 +23,7 @@ class PipelineFactory {
                             : "fp32",
                     decoder_model_merged: "q4", // or 'fp32' ('fp16' is broken)
                 },
-                device: "webgpu",
+                device: this.gpu ? "webgpu" : "wasm",
                 progress_callback,
             });
         }


### PR DESCRIPTION
Copy of [xenova/whisper-web #58](https://github.com/xenova/whisper-web/pull/58)

This PR removes the requirement to have WebGPU support in the browser and adds a checkbox to choose between GPU or no GPU. This checkbox is unchecked by default and disabled when WebGPU isn't available.

I am new to transformers.js so I'd like some extra feedback on [this line](https://github.com/PierreMesure/whisper-web/blob/cbb1b225210f52bdb5ecd12de7ab59c9e64296d0/src/worker.js#L26). Is this the best way to configure how it should run based on WebGPU availability? Is there any better option than `wasm`?

## Screenshots

Settings in Chrome:

![localhost_5173_](https://github.com/user-attachments/assets/18de0e90-9544-4ca9-91c6-e2165f92ab21)

Settings in Safari:

![Capture d’écran 2025-02-27 at 03 31 02](https://github.com/user-attachments/assets/cee6a241-6a9d-48ff-8d53-2318dc32f97e)